### PR TITLE
added a missing file in require paths

### DIFF
--- a/lib/kawaii_email_address.rb
+++ b/lib/kawaii_email_address.rb
@@ -1,0 +1,1 @@
+require 'kawaii_email_address/validator'


### PR DESCRIPTION
gemspec の require_paths となっている lib にロード対象の rb ファイルがなかったため、gem でインストールしても KawaiiEmailAddress がロードされない問題がありました
