### PR TITLE
Fix NameError in Ruby 1.9.3

### DIFF
--- a/lib/kawaii_email_address/validator.rb
+++ b/lib/kawaii_email_address/validator.rb
@@ -88,7 +88,7 @@ module KawaiiEmailAddress
     def valid_domain_literal?(domain)
       begin
         IPAddr.new(domain)
-      rescue IPAddr::InvalidAddressError
+      rescue ArgumentError
         false
       end
     end


### PR DESCRIPTION
Ruby 1.9.3 以前に `IPAddr::InvalidAddressError` は存在しないため、 Ruby 1.9.3 ではテストが落ちていました。
1.9.3 以前において `IPAddr.new` で渡す文字列が不正な際に発生する例外は `ArgumentError` でした。

[1.9.3 の ipaddr](https://github.com/ruby/ruby/blob/ruby_1_9_3/lib/ipaddr.rb#L514)
[2.0.0 の ipaddr](https://github.com/ruby/ruby/blob/ruby_2_0_0/lib/ipaddr.rb#L529)

`IPAddr::InvalidAddressError` は `ArgumentError` を継承しているので 2.0.0 以降においても捕捉はできます。

例外のメッセージまで見る、 IP の形式として文字列が正しいかを確認するための他の方法を探す、そもそも 1.9.3 以前をサポートしない、といった選択肢もありそうです。
