### PR TITLE
Fix RFC5322 compatible quoted_string

### DIFF
--- a/lib/kawaii_email_address/validator.rb
+++ b/lib/kawaii_email_address/validator.rb
@@ -58,8 +58,13 @@ module KawaiiEmailAddress
           end
 
         when DOUBLE_QUOTE # double quote delimits quoted strings
-          in_quoted_string = !in_quoted_string
-          next true
+          if i == 0
+            in_quoted_string = true
+            next true
+          elsif (i == local_part.length - 1) && in_quoted_string
+            in_quoted_string = false
+            next true
+          end
 
         when PERIOD
           period_restriction_violate_domain? ||

--- a/spec/kawaii_email_address_spec.rb
+++ b/spec/kawaii_email_address_spec.rb
@@ -20,6 +20,9 @@ describe KawaiiEmailAddress::Validator do
   it { should_not pass_validation_with '.aaa@example.com' }
 
   it { should pass_validation_with '"a@a"@example.com' }
+  it { should_not pass_validation_with 'a"b"@example.com' }
+  it { should_not pass_validation_with '"a"b@example.com' }
+  it { should_not pass_validation_with '"a"b"@example.com' }
   it { should pass_validation_with "'or'1'='1'--@example.com" }
 
   it { should_not pass_validation_with 'example_address' }


### PR DESCRIPTION
#11 へのPRとなります。

QuotedString は、ローカルパート全体を囲む仕様のようなので、
途中で DOUBLE_QUOTE が出現した場合に pass validation しない様に変更しました。

ご査収の程、よろしくお願いします。

This PR fixes rfc5322 compatibility bug.
The QuotedString should surround localpart not a part of localpart.
Please see specs about details.
