### PR TITLE
remove treat_symbols_as_metadata_keys_with_true_values setting

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -11,7 +11,6 @@ if ENV['CODECLIMATE_REPO_TOKEN'] && RUBY_VERSION.start_with?('2.1')
 end
 
 RSpec.configure do |config|
-  config.treat_symbols_as_metadata_keys_with_true_values = true
   config.run_all_when_everything_filtered = true
   config.filter_run :focus
 


### PR DESCRIPTION
> RSpec::Core::Configuration#treat_symbols_as_metadata_keys_with_true_values=
> is deprecated, it is now set to true as default and setting it to false
> has no effect.